### PR TITLE
Fixed the example to work with 0ms latencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a very simple class. Just create an instance, and run `ping()`.
 $host = 'www.example.com';
 $ping = new Ping($host);
 $latency = $ping->ping();
-if ($latency) {
+if ($latency !== false) {
   print 'Latency is ' . $latency . ' ms';
 }
 else {


### PR DESCRIPTION
The statement if($latency) would return false if the latency is 0ms. This could be the case when pinging localhost or a host on your LAN. By changing it to if($latency !== false) this is no longer the case.
