### PR TITLE
Update Ping.php

### DIFF
--- a/JJG/Ping.php
+++ b/JJG/Ping.php
@@ -204,7 +204,7 @@ class Ping {
           $latency = str_replace('ms', '', $latency);
         }
         // Convert latency to microseconds.
-        $latency = round($latency);
+        $latency = is_numeric($latency) ? round($latency) : false;
       }
     }
     else {


### PR DESCRIPTION
I don't think this a good fix for the issue we're having - but it does solve the current issue at hand.

When I get TTL exceeded under ubuntu 14.04 using exec, the response is (after array filter)
Array
(
    [0] => PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
    [1] => From 2.2.2.2 icmp_seq=1 Time to live exceeded
    [3] => --- 1.1.1.1 ping statistics ---
    [4] => 1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms
)

When key [1] is exploded, I get
Array
(
    [0] => From
    [1] => 2.2.2.2
    [2] => icmp_seq=1
    [3] => Time
    [4] => to
    [5] => live
    [6] => exceeded
)

The 6th index is expected to contain for example "time=30 ms". but instead contains 'exceeded'. 

round('exceeded') results in float(0) not false so the test falls apart

Any suggestions on how this might be made better are greatly appreciated, perhaps regex $output[1] for "time=(??) ms" - just a thought
