### PR TITLE
Replace parsing to regex to better match time=??ms

### DIFF
--- a/JJG/Ping.php
+++ b/JJG/Ping.php
@@ -193,7 +193,7 @@ class Ping {
     if (!empty($output[1])) {
 
       // $array = explode(' ', $output[1]);
-      $response = preg_match("/time(?:=|<)(?<time>[0-9]+)(?:|\s)ms/", $output[1], $matches);
+      $response = preg_match("/time(?:=|<)(?<time>[\.0-9]+)(?:|\s)ms/", $output[1], $matches);
 
       if($response > 0 && isset($matches['time']))
         $latency = round($matches['time']);


### PR DESCRIPTION
Following on from #18 here's an attempt at parsing (output[1]) with regex.

Handles sub 1ms pings, where windows prints < instead of =, eg time<1ms
Handles a minor different between unix and windows formats where unix has a space preceding the 'ms'
Have only tested sub 1000ms responses, unsure of OS's latency response format above 999ms ie 1000ms or 1,000ms
