### PR TITLE
Add support for timeout, fix OS X compatibility

### DIFF
--- a/JJG/PingTest.php
+++ b/JJG/PingTest.php
@@ -11,7 +11,7 @@ use JJG\Ping as Ping;
 
 class PingTest extends PHPUnit_Framework_TestCase {
   private $reachable_host = 'www.google.com';
-  private $unreachable_host = 'www.osdifjaosdg.com';
+  private $unreachable_host = '254.254.254.254';
 
   public function testHost() {
     $first = $this->reachable_host;
@@ -33,6 +33,15 @@ class PingTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($second, $ping->getTtl());
   }
 
+  public function testTimeout() {
+    $timeout = 5;
+    $startTime = microtime(true);
+    $ping = new Ping($this->unreachable_host, 255, $timeout);
+    $ping->ping('exec');
+    $time = floor(microtime(true) - $startTime);
+    $this->assertEquals($timeout, $time);
+  }
+  
   public function testPort() {
     $port = 2222;
     $ping = new Ping($this->reachable_host);
@@ -41,11 +50,11 @@ class PingTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testPingExec() {
-    $ping = new Ping('www.google.com');
+    $ping = new Ping($this->reachable_host );
     $latency = $ping->ping('exec');
     $this->assertNotEquals(FALSE, $latency);
 
-    $ping->setHost('www.sioajdsfonasdgiojsd.com');
+    $ping->setHost($this->unreachable_host);
     $latency = $ping->ping('exec');
     $this->assertEquals(FALSE, $latency);
   }


### PR DESCRIPTION
This pull request fixes #21 by adding an optional timeout parameter and also fixes support for OS X.  I have tested the timeout on Linux and OS X, but it has **not** been tested on Windows.  IF someone could test that for me that would be great!

I added a simple test for checking that the timeout works, it could definitely be improved.  I also set the `$unreachable_host` to a host that should never be able to be connected to rather than a domain that is simply unlikely to be resolved.

Please let me know if you see any issues.