### PR TITLE
Fixed package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ $ping->setHost('www.anotherexample.com');
 
 ## License
 
-Imap is licensed under the MIT (Expat) license. See included LICENSE.md.
+Ping is licensed under the MIT (Expat) license. See included LICENSE.md.


### PR DESCRIPTION
Just a name miss-match from copy/pasting README.md