### PR TITLE
Fixed FreeBSD ping exec call

### DIFF
--- a/JJG/Ping.php
+++ b/JJG/Ping.php
@@ -220,8 +220,8 @@ class Ping {
       // -n = number of pings; -i = ttl; -w = timeout (in milliseconds).
       $exec_string = 'ping -n 1 -i ' . $ttl . ' -w ' . ($timeout * 1000) . ' ' . $host;
     }
-    // Exec string for Darwin based systems (OS X).
-    else if(strtoupper(PHP_OS) === 'DARWIN') {
+    // Exec string for Darwin based systems (OS X) and FreeBSD.
+    else if(strtoupper(PHP_OS) === 'DARWIN' || strtoupper(PHP_OS) === 'FREEBSD') {
       // -n = numeric output; -c = number of pings; -m = ttl; -t = timeout.
       $exec_string = 'ping -n -c 1 -m ' . $ttl . ' -t ' . $timeout . ' ' . $host;
     }


### PR DESCRIPTION
There is a little bug when choosing how to assemble the `ping` command to feed to `exec`, if running on FreeBSD. As it is, FreeBSD falls into the command assembly for Linux, however, per the `ping` manpage in FreeBSD, the usage is identical to Darwin.

```
-m ttl  Set the IP Time To Live for outgoing packets.  If not specified,
             the kernel uses the value of the net.inet.ip.ttl MIB variable.

-t timeout
             Specify a timeout, in seconds, before ping exits regardless of
             how many packets have been received.
```

The main problem though is that `ping` does not fail when called with the Linux format, however, the params do a different thing:

```
-t timeout
             Specify a timeout, in seconds, before ping exits regardless of
             how many packets have been received.

-W waittime
             Time in milliseconds to wait for a reply for each packet sent.
             If a reply arrives later, the packet is not printed as replied,
             but considered as replied when calculating statistics.
```
