### PR TITLE
Hide stderr output

### DIFF
--- a/JJG/Ping.php
+++ b/JJG/Ping.php
@@ -228,7 +228,7 @@ class Ping {
     // Exec string for other UNIX-based systems (Linux).
     else {
       // -n = numeric output; -c = number of pings; -t = ttl; -W = timeout
-      $exec_string = 'ping -n -c 1 -t ' . $ttl . ' -W ' . $timeout . ' ' . $host;
+      $exec_string = 'ping -n -c 1 -t ' . $ttl . ' -W ' . $timeout . ' ' . $host . ' 2>&1';
     }
 
     exec($exec_string, $output, $return);


### PR DESCRIPTION
As mentioned in issue #23, it would be useful to hide raw stderr output. Since PHP's exec does not catch stderr output, we need to redirect it to stdout.