### PR TITLE
Support locales in ping output

### DIFF
--- a/JJG/Ping.php
+++ b/JJG/Ping.php
@@ -245,8 +245,8 @@ class Ping {
 
     // If the result line in the output is not empty, parse it.
     if (!empty($output[1])) {
-      // Search for a 'time' value in the result line.
-      $response = preg_match("/time(?:=|<)(?<time>[\.0-9]+)(?:|\s)ms/", $output[1], $matches);
+      // Search for a time value in the result line.
+      $response = preg_match("/(?:\w=|\w<)(?<time>[\.0-9]+)(?:|\s)ms/", $output[1], $matches);
 
       // If there's a result and it's greater than 0, return the latency.
       if ($response > 0 && isset($matches['time'])) {


### PR DESCRIPTION
Loosen the regex to search for a time value, to support non-english output of the ping command.

Since the output is generic in all languages we dont need to look for a specific english term.

This avoids introducing translations or keyword flags and so on.

Tested in German and English. I looked for other languages as well, almost all languages with latin characters use "ms" as abbreviation for milliseconds. 

```
German
export LANG=de_DE.UTF-8
PING gitlab.com (0.0.0.0) 56(84) Bytes Daten.64 Bytes von 0.0.0.0: icmp_seq=1 ttl=58 Zeit=19.0 ms--- gitlab.com ping statistics ---1 Pakete übertragen, 1 empfangen, 0% Paketverlust, Zeit 0msrtt min/avg/max/mdev = 19.028/19.028/19.028/0.000 msHost could not be reached.

English
export LANG=en_US.UTF-8
PING gitlab.com (0.0.0.0) 56(84) bytes of data.64 bytes from 0.0.0.0: icmp_seq=1 ttl=58 time=19.6 ms--- gitlab.com ping statistics ---1 packets transmitted, 1 received, 0% packet loss, time 0msrtt min/avg/max/mdev = 19.605/19.605/19.605/0.000 msLatency is 19.6 ms         
```

Issue #49 shows that this works in Chinese as well.

Unit Test were red before on my machine, green now. :tada: 

Refs #5 Refs #49

btw: Thanks for this package :)